### PR TITLE
replace undefined variable 'type' with 'service->mType' (#25393)

### DIFF
--- a/src/platform/ESP32/DnssdImpl.h
+++ b/src/platform/ESP32/DnssdImpl.h
@@ -104,7 +104,7 @@ struct ResolveContext : public GenericContext
     ResolveContext(DnssdService * service, Inet::InterfaceId ifId, mdns_search_once_t * searchHandle, DnssdResolveCallback cb,
                    void * cbCtx)
     {
-        Platform::CopyString(mType, type);
+        Platform::CopyString(mType, service->mType);
         Platform::CopyString(mInstanceName, service->mName);
         mContextType  = ContextType::Resolve;
         mProtocol     = service->mProtocol;


### PR DESCRIPTION
Fix build error in case esp-idf's mDNS implementation is used
