### PR TITLE
Hack: Use serial number to generate wifi api

### DIFF
--- a/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
@@ -941,11 +941,13 @@ CHIP_ERROR ConnectivityManagerImpl::ConfigureWiFiAP()
 
     uint16_t vendorId;
     uint16_t productId;
+    char serial[sizeof(wifiConfig.ap.ssid)-sizeof(CHIP_DEVICE_CONFIG_WIFI_AP_SSID_PREFIX)];
+    memset(serial, 0, sizeof(serial));
     ReturnErrorOnFailure(GetDeviceInstanceInfoProvider()->GetVendorId(vendorId));
     ReturnErrorOnFailure(GetDeviceInstanceInfoProvider()->GetProductId(productId));
+    ReturnErrorOnFailure(GetDeviceInstanceInfoProvider()->GetSerialNumber(serial, sizeof(serial)));
 
-    snprintf((char *) wifiConfig.ap.ssid, sizeof(wifiConfig.ap.ssid), "%s%03X-%04X-%04X", CHIP_DEVICE_CONFIG_WIFI_AP_SSID_PREFIX,
-             discriminator, vendorId, productId);
+    snprintf((char *) wifiConfig.ap.ssid, sizeof(wifiConfig.ap.ssid), "%s-%s", CHIP_DEVICE_CONFIG_WIFI_AP_SSID_PREFIX, serial);
     wifiConfig.ap.channel         = CHIP_DEVICE_CONFIG_WIFI_AP_CHANNEL;
     wifiConfig.ap.authmode        = WIFI_AUTH_OPEN;
     wifiConfig.ap.max_connection  = CHIP_DEVICE_CONFIG_WIFI_AP_MAX_STATIONS;


### PR DESCRIPTION
Matter has a specific SSID containing the vendor id and product id.
However Eltako also has a specific SSID format too.
Since we're not supporting commissioning using wifi, we can change the SSID to our variant.

This PR is a hack to change the way the SSID is composed to our variant.
To do this correctly we should either provide our own network management implementation or add functions to define how the SSID is composed.