### PR TITLE
Hack solution for aggregator recursive parts list

### DIFF
--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -211,6 +211,7 @@ void emberAfEndpointConfigure()
         for (ep = FIXED_ENDPOINT_COUNT; ep < MAX_ENDPOINT_COUNT; ep++)
         {
             emAfEndpoints[ep] = EmberAfDefinedEndpoint();
+            emAfEndpoints[ep].bitmask.Set(EmberAfEndpointOptions::isFlatComposition);
         }
     }
 #endif


### PR DESCRIPTION
When trying to bridge composed devices (devices which functionality is spread hierarchically over multiple endpoints) the aggregator needs to know all endpoints including all children of all aggregated devices.

Normally we should use the `SetFlatCompositionForEndpoint` for this purpose, yet this doesn't work as the endpoint needs to be deactivated before setting the flat composition (recursive look up of children endpoints).

Therefore we tell the system that all endpoints are flat composition.

This will become a problem when we have composed devices of multiple depths levels. In that case we need to set thos devices to tree composition or reset tree composition to the default and find a solution how to set flat composition for the aggregator device type

